### PR TITLE
Preserve transparency

### DIFF
--- a/src/sharp.js
+++ b/src/sharp.js
@@ -27,7 +27,7 @@ const transform = (image, options = {}) => {
       return image[key].apply(image, value);
     }
     return image;
-  }, image.clone().flatten());
+  }, image.clone());
 };
 
 /**


### PR DESCRIPTION
By removing the call to `flatten()` then we're able to preserve the alpha channel automatically without introducing the `background` attribute