### PR TITLE
Propagate `preset` value from config.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules
 examples
 *.log
 coverage
+flow-typed

--- a/src/sharp.js
+++ b/src/sharp.js
@@ -147,7 +147,14 @@ const createImageOptions = (
       config[key] = base[key];
     }
   });
-  return multiplex(config);
+  const out = multiplex(config);
+  out.forEach((item) => {
+    // NOTE: Can copy any non-multiplexed values here.
+    if (typeof outputOptions.preset === 'string') {
+      item.preset = outputOptions.preset;
+    }
+  });
+  return out;
 };
 
 const toArray = (x, defaultValue) => {


### PR DESCRIPTION
Only values in `allowedImageProperties` get multiplexed. Some things not in that bucket should still be copied over including `preset`.