### PR TITLE
Fix format loader option

### DIFF
--- a/src/internal/createImageObject.js
+++ b/src/internal/createImageObject.js
@@ -1,10 +1,12 @@
 // @flow
-import createName from './createName';
 import mime from 'mime';
-import serialize, {Serializable} from './serialize';
 
 import type {Meta} from 'sharp';
 import type {GlobalOptions, ImageObject, ImageOptions} from '../types';
+
+import createName from './createName';
+import parseFormat from './parseFormat';
+import serialize, {Serializable} from './serialize';
 
 const createImageObject = (
   input: Buffer,
@@ -14,10 +16,15 @@ const createImageObject = (
   globalOptions: GlobalOptions,
   loader: *,
 ): ImageObject => {
-  const n = createName(input, info, options, globalOptions, loader);
+  const {format: rawFormat, ...rest} = options;
+  const [format, formatOptions] = parseFormat(rawFormat);
+
+  const n = createName(input, info, format, options, globalOptions, loader);
   const type = mime.getType(n);
   const result = {
-    ...options,
+    ...rest,
+    format,
+    formatOptions,
     width: info.width,
     height: info.height,
     type,

--- a/src/internal/createImageObject.js
+++ b/src/internal/createImageObject.js
@@ -11,22 +11,22 @@ import serialize, {Serializable} from './serialize';
 const createImageObject = (
   input: Buffer,
   image: ?Buffer,
-  info: $Supertype<Meta>,
+  meta: $Supertype<Meta>,
   options: ImageOptions,
   globalOptions: GlobalOptions,
   loader: *,
 ): ImageObject => {
-  const {format: rawFormat, ...rest} = options;
+  const {format: rawFormat = meta.format, ...rest} = options;
   const [format, formatOptions] = parseFormat(rawFormat);
 
-  const n = createName(input, info, format, options, globalOptions, loader);
+  const n = createName(input, meta, format, options, globalOptions, loader);
   const type = mime.getType(n);
   const result = {
     ...rest,
     format,
     formatOptions,
-    width: info.width,
-    height: info.height,
+    width: meta.width,
+    height: meta.height,
     type,
     name: n,
     url: null,

--- a/src/internal/createName.js
+++ b/src/internal/createName.js
@@ -10,16 +10,17 @@ import hashOptions from './hashOptions';
  * @returns {String} Extension.
  */
 const extension = (type: string): string => {
-  return {
-    webp: '.webp',
-    jpeg: '.jpg',
-    png: '.png',
-  }[type];
+  return (
+    {
+      jpeg: '.jpg',
+    }[type] || `.${type}`
+  );
 };
 
 const createName = (
   image: Buffer,
   info: *,
+  format: string,
   params: *,
   globalOptions: GlobalOptions,
   loader: *,
@@ -39,9 +40,11 @@ const createName = (
     }
     return str;
   });
+
   const resourcePath = loader.resourcePath
     .replace(/@([0-9]+)x\./, '.')
-    .replace(/\.[^.]+$/, extension(info.format));
+    .replace(/\.[^.]+$/, extension(format));
+
   const content = Buffer.concat([new Buffer(hashOptions(params)), image]);
   return loaderUtils.interpolateName(
     {

--- a/src/internal/createSharpOptions.js
+++ b/src/internal/createSharpOptions.js
@@ -3,6 +3,8 @@ import sharp from 'sharp';
 
 import type {ImageOptions, SharpOptions} from '../types';
 
+import parseFormat from './parseFormat';
+
 /**
  * Take some configuration options and transform them into a format that
  * `transform` is capable of using.
@@ -12,9 +14,9 @@ import type {ImageOptions, SharpOptions} from '../types';
  */
 const createSharpOptions = (options: ImageOptions, meta: *): SharpOptions => {
   const result = {};
-  if (typeof options.format === 'string') {
-    result.toFormat = options.format;
-  }
+
+  const [format, formatOptions] = parseFormat(options.format);
+  result.toFormat = [sharp.format[format], formatOptions];
 
   // Sizing
   if (typeof options.width === 'number' || typeof options.height === 'number') {

--- a/src/internal/createSharpOptions.js
+++ b/src/internal/createSharpOptions.js
@@ -15,7 +15,9 @@ import parseFormat from './parseFormat';
 const createSharpOptions = (options: ImageOptions, meta: *): SharpOptions => {
   const result = {};
 
-  const [format, formatOptions] = parseFormat(options.format);
+  const {format: rawFormat = meta.format} = options;
+
+  const [format, formatOptions] = parseFormat(rawFormat);
   result.toFormat = [sharp.format[format], formatOptions];
 
   // Sizing

--- a/src/internal/parseFormat.js
+++ b/src/internal/parseFormat.js
@@ -1,0 +1,14 @@
+// @flow
+
+import type {Format, FormatOptions} from '../types';
+
+function parseFormat(format: Format): [string, FormatOptions] {
+  if (typeof format === 'string') {
+    return [format, {}];
+  }
+
+  const {id, ...options} = format;
+  return [(id: string), options];
+}
+
+export default parseFormat;

--- a/src/types.js
+++ b/src/types.js
@@ -14,7 +14,7 @@ export type Format = string | ({id: string} & FormatOptions);
 
 export type ImageOptions = {|
   name?: string,
-  format: Format,
+  format?: Format,
   width?: number,
   height?: number,
   scale?: number,

--- a/src/types.js
+++ b/src/types.js
@@ -6,9 +6,15 @@ export type SharpMeta = {|
   format: string,
 |};
 
+export type FormatOptions = {
+  [key: string]: string | number | boolean,
+};
+
+export type Format = string | ({id: string} & FormatOptions);
+
 export type ImageOptions = {|
   name?: string,
-  format?: string,
+  format: Format,
   width?: number,
   height?: number,
   scale?: number,
@@ -21,6 +27,7 @@ export type ImageOptions = {|
 export type ImageObject = {
   name: string,
   format: string,
+  formatOptions: FormatOptions,
   width: number,
   height: number,
   preset?: string,
@@ -31,7 +38,7 @@ export type ImageObject = {
 export type SharpOptions = {
   max?: boolean,
   min?: boolean,
-  toFormat?: string,
+  toFormat?: string | [string, FormatOptions],
   blur?: number,
   resize?: [?number, ?number],
   crop?: *,


### PR DESCRIPTION
Support for format as an object (as documented in the README) has not actually worked up to now.

```js
  return ['webp', {id: 'jpeg', quality: 70}];
```
see: [complex-example](https://github.com/metalabdesign/sharp-loader/blob/master/README.md#complex-example)

This change fixes the loader to work as described.