### PR TITLE
Replace id with format

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You can also avoid any processing and just emit the expected metadata:
         if (meta.hasAlpha) {
           return ['webp', 'png'];
         }
-        return ['webp', {id: 'jpeg', quality: 70}];
+        return ['webp', {format: 'jpeg', quality: 70}];
       },
       scale: (meta) => {
         // If the image has no intrinsic scaling just ignore it.
@@ -141,7 +141,7 @@ You can also avoid any processing and just emit the expected metadata:
         if (meta.hasAlpha) {
           return 'png';
         }
-        return {id: 'jpeg', quality: 40};
+        return {format: 'jpeg', quality: 40};
       },
       blur: 100,
       inline: true,

--- a/src/internal/parseFormat.js
+++ b/src/internal/parseFormat.js
@@ -2,13 +2,19 @@
 
 import type {Format, FormatOptions} from '../types';
 
-function parseFormat(format: Format): [string, FormatOptions] {
-  if (typeof format === 'string') {
-    return [format, {}];
+function parseFormat(rawFormat: Format): [string, FormatOptions] {
+  if (typeof rawFormat === 'string') {
+    return [rawFormat, {}];
   }
 
-  const {id, ...options} = format;
-  return [(id: string), options];
+  const {
+    id,
+    // Support deprecated `id` property as alias for `format`
+    format = (id: any), // flowlint-line unclear-type: off
+    ...options
+  } = rawFormat;
+
+  return [format, options];
 }
 
 export default parseFormat;

--- a/src/types.js
+++ b/src/types.js
@@ -10,7 +10,7 @@ export type FormatOptions = {
   [key: string]: string | number | boolean,
 };
 
-export type Format = string | ({id: string} & FormatOptions);
+export type Format = string | ({format: string} & FormatOptions);
 
 export type ImageOptions = {|
   name?: string,


### PR DESCRIPTION
Deprecate `format: {id: 'png'}` in favor of `format: {format: 'png'}` to improve consistency across the loader interface.